### PR TITLE
Add .dockerignore to exclude specific directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Ignore node modules
+node_modules/
+
+# Ignorem music folder
+music
+
+# Ignore navidrome data folder
+data


### PR DESCRIPTION
Why would you copy node_modules in the builder